### PR TITLE
Add app structure spec and expand infinite command

### DIFF
--- a/.claude/commands/infinite.md
+++ b/.claude/commands/infinite.md
@@ -7,12 +7,14 @@ Think deeply about this infinite generation task. You are about to embark on a s
 spec_file: $ARGUMENTS
 output_dir: $ARGUMENTS
 count: $ARGUMENTS
+project_path: $ARGUMENTS
 
 **ARGUMENTS PARSING:**
 Parse the following arguments from "$ARGUMENTS":
 1. `spec_file` - Path to the markdown specification file
-2. `output_dir` - Directory where iterations will be saved  
+2. `output_dir` - Directory where iterations will be saved
 3. `count` - Number of iterations (1-N or "infinite")
+4. `project_path` - Root directory of the target project to merge results into
 
 **PHASE 1: SPECIFICATION ANALYSIS**
 Read and deeply understand the specification file at `spec_file`. This file defines:
@@ -23,8 +25,8 @@ Read and deeply understand the specification file at `spec_file`. This file defi
 
 Think carefully about the spec's intent and how each iteration should build upon previous work.
 
-**PHASE 2: OUTPUT DIRECTORY RECONNAISSANCE** 
-Thoroughly analyze the `output_dir` to understand the current state:
+**PHASE 2: OUTPUT DIRECTORY RECONNAISSANCE**
+Thoroughly analyze the `output_dir` and existing `project_path` to understand the current state:
 - List all existing files and their naming patterns
 - Identify the highest iteration number currently present
 - Analyze the content evolution across existing iterations
@@ -42,9 +44,18 @@ Based on the spec analysis and existing iterations:
 Deploy multiple Sub Agents to generate iterations in parallel for maximum efficiency and creative diversity:
 
 **Sub-Agent Distribution Strategy:**
-- For count 1-5: Launch all agents simultaneously 
+- For count 1-5: Launch all agents simultaneously
 - For count 6-20: Launch in batches of 5 agents to manage coordination
 - For "infinite": Launch waves of 3-5 agents, monitoring context and spawning new waves
+
+**Sub-Agent Roles and Output Folders:**
+1. **CEO/Manager** - breaks down the spec and assigns tasks. Output to `manager/`.
+2. **CTO/Programmer** - implements core functionality. Output to `programmer/`.
+3. **Reviewer** - reviews and suggests improvements. Output to `reviewer/`.
+4. **Tester** - writes tests and validation scripts. Output to `tester/`.
+5. **Designer** - creates UI/UX assets or mockups. Output to `designer/`.
+
+Each role receives only the relevant portion of the specification along with its dedicated folder inside `output_dir`.
 
 **Agent Assignment Protocol:**
 Each Sub Agent receives:
@@ -84,7 +95,14 @@ DELIVERABLE: Single file as specified, with unique innovative content
 - Ensure no duplicate iteration numbers are generated
 - Collect and validate all completed iterations
 
-**PHASE 5: INFINITE MODE ORCHESTRATION**
+**PHASE 5: MERGING RESULTS**
+After all sub-agents finish their work:
+- Combine the contents of each role's output folder into `project_path`.
+- Resolve conflicts by preferring reviewed and tested files.
+- Maintain the directory structure defined in the specification.
+- Provide a summary of merged files and any issues.
+
+**PHASE 6: INFINITE MODE ORCHESTRATION**
 For infinite generation mode, orchestrate continuous parallel waves:
 
 **Wave-Based Generation:**

--- a/README.md
+++ b/README.md
@@ -18,36 +18,43 @@ Start Claude Code: `claude`
 
 Type slash command `/project:infinite` to start the infinite agentic loop.
 
-The infinite command takes three arguments:
+The infinite command now takes four arguments:
 ```
-/project:infinite <spec_file> <output_dir> <count>
+/project:infinite <spec_file> <output_dir> <count> <project_path>
 ```
 
 ### 4 Command Variants
 
 #### 1. Single Generation
 ```bash
-/project:infinite specs/invent_new_ui_v3.md src 1
+/project:infinite specs/invent_new_ui_v3.md src 1 my_project
 ```
 Generate one new iteration using the UI specification.
 
 #### 2. Small Batch (5 iterations)
 ```bash
-/project:infinite specs/invent_new_ui_v3.md src_new 5
+/project:infinite specs/invent_new_ui_v3.md src_new 5 my_project
 ```
 Deploy 5 parallel agents to generate 5 unique iterations simultaneously.
 
-#### 3. Large Batch (20 iterations)  
+#### 3. Large Batch (20 iterations)
 ```bash
-/project:infinite specs/invent_new_ui_v3.md src_new 20
+/project:infinite specs/invent_new_ui_v3.md src_new 20 my_project
 ```
 Generate 20 iterations in coordinated batches of 5 agents for optimal resource management.
 
 #### 4. Infinite Mode
 ```bash
-/project:infinite specs/invent_new_ui_v3.md infinite_src_new/ infinite
+/project:infinite specs/invent_new_ui_v3.md infinite_src_new/ infinite my_project
 ```
 Continuous generation in waves until context limits are reached, with progressive sophistication.
+
+### Example: Generate a multi-file project
+Use the folder structure spec to bootstrap an application skeleton:
+```bash
+/project:infinite specs/app_structure_spec.md scaffold 1 my_project
+```
+This command creates the directories and placeholder files described in the spec and merges them into `my_project`.
 
 ## How It Works
 

--- a/specs/app_structure_spec.md
+++ b/specs/app_structure_spec.md
@@ -1,0 +1,28 @@
+# Application Folder Structure Specification
+
+## Purpose
+Define the directory and file layout for a complete multi-file application. This specification is language agnostic so it can be adapted to different tech stacks.
+
+## Base Directories
+- **src/** - All application source code
+  - **components/** - Reusable modules or classes
+  - **utils/** - Shared helper functions
+- **tests/** - Automated test suites
+- **public/** - Static assets served directly to the client
+- **docs/** - Project documentation and design notes
+- **build/** - Compiled or bundled output
+
+## Required Files
+- `README.md` explaining how to run and build the app
+- `LICENSE` file specifying project license
+- `package.json` or `pyproject.toml` describing dependencies (choose appropriate for stack)
+- Configuration files such as `.gitignore` and linting/formatting configs
+
+## File Generation Rules
+1. Each directory must contain at least one placeholder file if no real content exists yet.
+2. Testing code goes exclusively under `tests/`.
+3. Production source files reside only in `src/` and its subfolders.
+4. Design documents and diagrams live in `docs/`.
+5. Compiled assets are written to `build/` and should not be committed.
+
+Use this structure when generating a new project so all agents know where to place their output.


### PR DESCRIPTION
## Summary
- add `app_structure_spec.md` describing folder layout for a full application
- update `/project:infinite` command to accept a project path, define specific sub-agent roles, and merge outputs into the project directory
- document new command syntax and provide example usage generating a multi-file project

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bff3f6e788330a0afe51a65cdac8d